### PR TITLE
fix syntaxError unexpected token '/'

### DIFF
--- a/views/login.ejs
+++ b/views/login.ejs
@@ -2,7 +2,7 @@
   <div class="col-md-6 m-auto">
     <div class="card card-body">
       <h1 class="text-center mb-3"><i class="fas fa-sign-in-alt"></i>  Login</h1>
-      <% include ./partials/messages %>
+      <%- include("./partials/messages") %>
       <form action="/users/login" method="POST">
         <div class="form-group">
           <label for="email">Email</label>


### PR DESCRIPTION
fixes : #117
Issue:
The error occurs due to incorrect syntax in the EJS file, preventing the partial from being included properly.

Solution:
Corrected the syntax in login.ejs to properly include the partial, ensuring that the EJS file renders correctly without errors. This fix allows the login page to function as intended.