### PR TITLE
Set cookie expiration

### DIFF
--- a/app.js
+++ b/app.js
@@ -32,9 +32,12 @@ app.use(express.urlencoded({ extended: true }));
 // Express session
 app.use(
   session({
-    secret: 'secret',
+    secret: "secret",
     resave: true,
-    saveUninitialized: true
+    saveUninitialized: true,
+    cookie: {
+      maxAge: 1000 * 60 * 60 * 24 * 30, // 30 days
+    },
   })
 );
 

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -2,7 +2,7 @@
   <div class="col-md-6 m-auto">
     <div class="card card-body">
       <h1 class="text-center mb-3"><i class="fas fa-sign-in-alt"></i>  Login</h1>
-      <% include ./partials/messages %>
+      <%- include("./partials/messages") %>
       <form action="/users/login" method="POST">
         <div class="form-group">
           <label for="email">Email</label>


### PR DESCRIPTION
fixes #133

Issue:
Cookies were being created without an expiration time, causing them to expire at the end of the session by default. This behavior can lead to unintended logout issues and lack of persistence for user sessions.

Solution:
Updated the cookie configuration to include a 30-day expiration time. This change ensures that cookies have a defined lifespan, improving session management and user experience.