### PR TITLE
Fix EJS partial include syntax

### DIFF
--- a/views/login.ejs
+++ b/views/login.ejs
@@ -2,7 +2,7 @@
   <div class="col-md-6 m-auto">
     <div class="card card-body">
       <h1 class="text-center mb-3"><i class="fas fa-sign-in-alt"></i>  Login</h1>
-      <% include ./partials/messages %>
+      <%- include("./partials/messages") %>
       <form action="/users/login" method="POST">
         <div class="form-group">
           <label for="email">Email</label>

--- a/views/register.ejs
+++ b/views/register.ejs
@@ -4,7 +4,7 @@
       <h1 class="text-center mb-3">
         <i class="fas fa-user-plus"></i> Register
       </h1>
-      <%= include ("./partials/messages"); %>
+      <%- include("./partials/messages") %>
       <form action="/users/register" method="POST">
         <div class="form-group">
           <label for="name">Name</label>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk template-only change that standardizes EJS `include` usage; main risk is minor rendering differences if escaping behavior changes.
> 
> **Overview**
> Fixes the flash/message partial rendering on the login and register pages by updating the EJS include syntax to ` <%- include("./partials/messages") %>`.
> 
> This replaces inconsistent/incorrect include forms so the `messages` partial is reliably injected into both templates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65b1288294e64590ae38e1753c759252c79206ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->